### PR TITLE
Fix Select Data checks now only check type tdwg_standard

### DIFF
--- a/.github/workflows/Level 1 CI.yml
+++ b/.github/workflows/Level 1 CI.yml
@@ -1,0 +1,21 @@
+# This work flow only works when a repository_dispatch event with custom type "bdverse-level-CI-trigger" happens.
+#It must be in Master branch.
+
+name:  Level 1 CI
+on:
+  repository_dispatch:
+    types: [bdverse-level-CI-trigger]
+jobs:
+  R-CMD-check:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@master
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}

--- a/.github/workflows/bdchecks-app-master-branch-CI.yml
+++ b/.github/workflows/bdchecks-app-master-branch-CI.yml
@@ -1,0 +1,24 @@
+name: bdchecks-app-master-branch-CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  R-CMD-check:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@master
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}

--- a/R/mod_configure_checks.R
+++ b/R/mod_configure_checks.R
@@ -21,59 +21,61 @@ mod_configure_checks_ui <- function(id) {
   components <- list()
   
   for (check in bdchecks::data.checks@dc_body) {
-    components[[length(components) + 1]] <- tagList(
-    div(
-      class = paste("element-item checksListContent", darwinCoreClass[check@name, ]$group),
-      
-      HTML(
-        paste(
-          "<input type=checkbox name=", ns("typeInput"), " value=", check@name, ">"
-        )
-      ),
-      
-      fluidRow(column(6, div(h4(check@name), class = "leftSide")), column(6, div("", class = "rightSide"))), 
-      
-      conditionalPanel(
-        "input['bdChecksConfigure-showDetailed'] == true",
+    if(check@information$check_type=="tdwg_standard"){
+      components[[length(components) + 1]] <- tagList(
         div(
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Description: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@information$description))
+          class = paste("element-item checksListContent", darwinCoreClass[check@name, ]$group),
+          
+          HTML(
+            paste(
+              "<input type=checkbox name=", ns("typeInput"), " value=", check@name, ">"
+            )
           ),
           
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Sample Passing Data: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(paste(check@example$pass, check@example$input_pass)))
-          ),
+          fluidRow(column(6, div(h4(check@name), class = "leftSide")), column(6, div("", class = "rightSide"))), 
           
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Sample Failing Data: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(paste(check@example$fail, check@example$input_fail)))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Category of Check: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@information$darwin_core_class))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("DWC Field Targetted: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@input$target))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Sorting Flags: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@information$keywords))
+          conditionalPanel(
+            "input['bdChecksConfigure-showDetailed'] == true",
+            div(
+              fluidRow(
+                div(class = "checksListTopic col-sm-4", p("Description: ")),
+                div(class = "checksListTitle col-sm-8",
+                    p(check@information$description))
+              ),
+              
+              fluidRow(
+                div(class = "checksListTopic col-sm-4", p("Sample Passing Data: ")),
+                div(class = "checksListTitle col-sm-8",
+                    p(paste(check@example$pass, check@example$input_pass)))
+              ),
+              
+              fluidRow(
+                div(class = "checksListTopic col-sm-4", p("Sample Failing Data: ")),
+                div(class = "checksListTitle col-sm-8",
+                    p(paste(check@example$fail, check@example$input_fail)))
+              ),
+              
+              fluidRow(
+                div(class = "checksListTopic col-sm-4", p("Category of Check: ")),
+                div(class = "checksListTitle col-sm-8",
+                    p(check@information$darwin_core_class))
+              ),
+              
+              fluidRow(
+                div(class = "checksListTopic col-sm-4", p("DWC Field Targetted: ")),
+                div(class = "checksListTitle col-sm-8",
+                    p(check@input$target))
+              ),
+              
+              fluidRow(
+                div(class = "checksListTopic col-sm-4", p("Sorting Flags: ")),
+                div(class = "checksListTitle col-sm-8",
+                    p(check@information$keywords))
+              )
+            )
           )
-        )
-      )
-    ))
+        ))
+    }
   }
   
   tagList(column(

--- a/R/mod_configure_checks.R
+++ b/R/mod_configure_checks.R
@@ -21,60 +21,74 @@ mod_configure_checks_ui <- function(id) {
   components <- list()
   
   for (check in bdchecks::data.checks@dc_body) {
-    if(check@information$check_type=="tdwg_standard"){
-      components[[length(components) + 1]] <- tagList(
-        div(
-          class = paste("element-item checksListContent", darwinCoreClass[check@name, ]$group),
-          
-          HTML(
-            paste(
-              "<input type=checkbox name=", ns("typeInput"), " value=", check@name, ">"
-            )
-          ),
-          
-          fluidRow(column(6, div(h4(check@name), class = "leftSide")), column(6, div("", class = "rightSide"))), 
-          
-          conditionalPanel(
-            "input['bdChecksConfigure-showDetailed'] == true",
-            div(
-              fluidRow(
-                div(class = "checksListTopic col-sm-4", p("Description: ")),
-                div(class = "checksListTitle col-sm-8",
-                    p(check@information$description))
-              ),
-              
-              fluidRow(
-                div(class = "checksListTopic col-sm-4", p("Sample Passing Data: ")),
-                div(class = "checksListTitle col-sm-8",
-                    p(paste(check@example$pass, check@example$input_pass)))
-              ),
-              
-              fluidRow(
-                div(class = "checksListTopic col-sm-4", p("Sample Failing Data: ")),
-                div(class = "checksListTitle col-sm-8",
-                    p(paste(check@example$fail, check@example$input_fail)))
-              ),
-              
-              fluidRow(
-                div(class = "checksListTopic col-sm-4", p("Category of Check: ")),
-                div(class = "checksListTitle col-sm-8",
-                    p(check@information$darwin_core_class))
-              ),
-              
-              fluidRow(
-                div(class = "checksListTopic col-sm-4", p("DWC Field Targetted: ")),
-                div(class = "checksListTitle col-sm-8",
-                    p(check@input$target))
-              ),
-              
-              fluidRow(
-                div(class = "checksListTopic col-sm-4", p("Sorting Flags: ")),
-                div(class = "checksListTitle col-sm-8",
-                    p(check@information$keywords))
-              )
+    if (check@information$check_type == "tdwg_standard") {
+      components[[length(components) + 1]] <- tagList(div(
+        class = paste(
+          "element-item checksListContent",
+          darwinCoreClass[check@name,]$group
+        ),
+        
+        HTML(
+          paste(
+            "<input type=checkbox name=",
+            ns("typeInput"),
+            " value=",
+            check@name,
+            ">"
+          )
+        ),
+        
+        fluidRow(column(6, div(
+          h4(check@name), class = "leftSide"
+        )), column(6, div("", class = "rightSide"))),
+        
+        conditionalPanel(
+          "input['bdChecksConfigure-showDetailed'] == true",
+          div(
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Description: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(check@information$description))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Sample Passing Data: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(
+                    paste(check@example$pass, check@example$input_pass)
+                  ))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Sample Failing Data: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(
+                    paste(check@example$fail, check@example$input_fail)
+                  ))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Category of Check: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(
+                    check@information$darwin_core_class
+                  ))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("DWC Field Targetted: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(check@input$target))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Sorting Flags: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(check@information$keywords))
             )
           )
-        ))
+        )
+      ))
     }
   }
   
@@ -136,16 +150,12 @@ mod_configure_checks_ui <- function(id) {
       column(
         4,
         p("Quick Options:"),
-        actionButton(
-          ns("all"),
-          label = "Select All"
-        ),
-        actionButton(
-          ns("none"),
-          label = "Deselect All"
-        )
+        actionButton(ns("all"),
+                     label = "Select All"),
+        actionButton(ns("none"),
+                     label = "Deselect All")
       )
-     
+      
     )),
     
     div(id = ns("typeInput"),
@@ -176,19 +186,15 @@ mod_configure_checks_server <- function(input, output, session) {
   })
   
   observeEvent(input$all, {
-    updateCheckboxGroupInput(
-      session,
-      "typeInput",
-      selected = names(bdchecks::data.checks@dc_body)
-    )
+    updateCheckboxGroupInput(session,
+                             "typeInput",
+                             selected = names(bdchecks::data.checks@dc_body))
   })
   
   observeEvent(input$none, {
-    updateCheckboxGroupInput(
-      session,
-      "typeInput",
-      selected = names(bdchecks::data.checks@dc_body[1000])
-    )
+    updateCheckboxGroupInput(session,
+                             "typeInput",
+                             selected = names(bdchecks::data.checks@dc_body[1000]))
   })
   
   returnDataReact <- reactive({

--- a/R/mod_configure_checks.R
+++ b/R/mod_configure_checks.R
@@ -126,9 +126,9 @@ mod_configure_checks_ui <- function(id) {
           "data-sort-value" = ".event"
         ),
         actionButton(
-          "filterByOccurence",
+          "filterByOccurrence",
           class = "button is-checked ",
-          label = "Occurence",
+          label = "Occurrence",
           "data-sort-value" = ".occurrence"
         ),
         actionButton(
@@ -173,6 +173,8 @@ mod_configure_checks_ui <- function(id) {
 #' @keywords internal
 mod_configure_checks_server <- function(input, output, session) {
   ns <- session$ns
+  classes <- get_dc_groups("DarwinCoreClass")
+  values <- NULL
   
   returnData <- character()
   
@@ -186,15 +188,40 @@ mod_configure_checks_server <- function(input, output, session) {
   })
   
   observeEvent(input$all, {
+    if (input$currentSort == "All" ||
+        input$currentSort == "AllLocationTaxonEventOccurrenceRecord-level Terms") {
+      names <- names(bdchecks::data.checks@dc_body)
+    } else {
+      names  <-
+        as.character(classes[classes$groupName == tolower(input$currentSort), 1])
+    }
+    
+    if (!is.null(values)) {
+      names <- union(names, values)
+    }
+    values <<- names
+    
     updateCheckboxGroupInput(session,
                              "typeInput",
-                             selected = names(bdchecks::data.checks@dc_body))
+                             selected = names)
   })
   
   observeEvent(input$none, {
+    if (input$currentSort == "All" ||
+        input$currentSort == "AllLocationTaxonEventOccurrenceRecord-level Terms") {
+      values <<- NA
+    } else {
+      values  <<-
+        setdiff(values,
+                as.character(classes[classes$groupName == tolower(input$currentSort), 1]))
+      if (length(values) == 0) {
+        values <<- NA
+      }
+    }
+    
     updateCheckboxGroupInput(session,
                              "typeInput",
-                             selected = names(bdchecks::data.checks@dc_body[1000]))
+                             selected = values)
   })
   
   returnDataReact <- reactive({


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

# Description

In tab Select Data checks

To show only check type tdwg_standard; https://github.com/bd-R/bdchecks/blob/456791e80760fc6428645f92faf3cf3bc63388d7/inst/extdata/data_check.yaml#L2248

And not to show check type bdclean; https://github.com/bd-R/bdchecks/blob/456791e80760fc6428645f92faf3cf3bc63388d7/inst/extdata/data_check.yaml#L2295

Fixes #35 


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] RCMD
- [ ] Unit Tests
- [ ] Shiny Tests
- [ ] Manual Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors in the package
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Todos
- [ ] Tests
- [ ] Documentation


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

#### Environment Details
R Version:
OS:

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots
