### PR TITLE
Fix: To show only check type tdwg_standard, and not to show check type bdclean.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: bdchecks.app
 Title: A User-Friendly Graphical Interface for Managing Biodiversity Data Quality Checks
 Description: Shiny App giving complete workflow to selectively perform datachecks.
-Version: 0.2.3
-Date: 2020-05-23
+Version: 0.2.4
+Date: 2020-09-27
 Authors@R: c(
     person(
         "Tomer", "Gueta", 
@@ -49,6 +49,6 @@ Remotes:
     bd-R/bdutilities.app,
     bd-R/bdutilities,
     bd-R/bdchecks
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 URL: https://github.com/bd-R/bdchecks.app
 BugReports: https://github.com/bd-R/bdchecks.app/issues

--- a/R/mod_configure_checks.R
+++ b/R/mod_configure_checks.R
@@ -21,70 +21,75 @@ mod_configure_checks_ui <- function(id) {
   components <- list()
   
   for (check in bdchecks::data.checks@dc_body) {
-    components[[length(components) + 1]] <- tagList(div(
-      class = paste("element-item checksListContent", darwinCoreClass[check@name,]$group),
-      
-      HTML(
-        paste(
-          "<input type=checkbox name=",
-          ns("typeInput"),
-          " value=",
-          check@name,
-          ">"
-        )
-      ),
-      
-      fluidRow(column(6, div(
-        h4(check@name), class = "leftSide"
-      )), column(6, div("", class = "rightSide"))),
-      
-      conditionalPanel(
-        "input['bdChecksConfigure-showDetailed'] == true",
-        div(
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Description: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@information$description))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Sample Passing Data: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(
-                  paste(check@example$pass, check@example$input_pass)
-                ))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Sample Failing Data: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(
-                  paste(check@example$fail, check@example$input_fail)
-                ))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Category of Check: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(
-                  check@information$darwin_core_class
-                ))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("DWC Field Targetted: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@input$target))
-          ),
-          
-          fluidRow(
-            div(class = "checksListTopic col-sm-4", p("Sorting Flags: ")),
-            div(class = "checksListTitle col-sm-8",
-                p(check@information$keywords))
+    if (check@information$check_type == "tdwg_standard") {
+      components[[length(components) + 1]] <- tagList(div(
+        class = paste(
+          "element-item checksListContent",
+          darwinCoreClass[check@name, ]$group
+        ),
+        
+        HTML(
+          paste(
+            "<input type=checkbox name=",
+            ns("typeInput"),
+            " value=",
+            check@name,
+            ">"
+          )
+        ),
+        
+        fluidRow(column(6, div(
+          h4(check@name), class = "leftSide"
+        )), column(6, div("", class = "rightSide"))),
+        
+        conditionalPanel(
+          "input['bdChecksConfigure-showDetailed'] == true",
+          div(
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Description: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(check@information$description))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Sample Passing Data: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(
+                    paste(check@example$pass, check@example$input_pass)
+                  ))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Sample Failing Data: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(
+                    paste(check@example$fail, check@example$input_fail)
+                  ))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Category of Check: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(
+                    check@information$darwin_core_class
+                  ))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("DWC Field Targetted: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(check@input$target))
+            ),
+            
+            fluidRow(
+              div(class = "checksListTopic col-sm-4", p("Sorting Flags: ")),
+              div(class = "checksListTitle col-sm-8",
+                  p(check@information$keywords))
+            )
           )
         )
-      )
-    ))
+      ))
+    }
   }
   
   tagList(column(

--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -11,4 +11,4 @@
 # Run the application
 
 
-options(golem.app.prod = FALSE); golem::detach_all_attached(); golem::document_and_reload(); bdchecks.app::run_app()
+options(golem.app.prod = FALSE); golem::detach_all_attached(); golem::document_and_reload(); bdchecks.app::bdchecks_app()


### PR DESCRIPTION
## Status
**READY**

# Description
This PR fixes issue #35 . 
The ticket was to change bdchecks.app to show only check type tdwg_standard, and not to show check type bdclean.

Fixes #35 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] RCMD
- [x] Package Installation from Github
- [x] Travis / Github Workflow
- [x] Unit Tests
- [x] Shiny Tests
- [x] Manual Tests

# Checklist:

- [x] I have updated DESCRIPTION with date, version, dependencies
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors in the package
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Todos
- [ ] Tests
- [ ] Documentation

